### PR TITLE
Initial Express + Prisma scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://user:password@localhost:5432/dharmalayam

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+prisma/dev.db
+build

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # Dharmalayam
+
+This repository contains a minimal scaffolding of the Dharmalayam project described in the specification. It includes a TypeScript Express server and Prisma schema representing the main database models.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+2. Provide a PostgreSQL connection string in a `.env` file:
+   ```env
+   DATABASE_URL=postgresql://user:password@localhost:5432/dharmalayam
+   ```
+3. Run Prisma migrations:
+   ```bash
+   npx prisma migrate dev --name init
+   ```
+4. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Note
+
+The environment used for generating this repository does not have internet access, so dependencies cannot be installed or commands executed here. Ensure you run the above steps in an environment with internet connectivity.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dharmalayam",
+  "version": "1.0.0",
+  "description": "Dharmalayam API server",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/index.js",
+    "dev": "ts-node src/index.ts",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.0",
+    "prisma": "^5.0.0",
+    "@prisma/client": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,143 @@
+// Prisma schema for Dharmalayam
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id                String    @id @default(uuid())
+  phone             String?   @unique
+  email             String?   @unique
+  username          String?   @unique
+  passwordHash      String?
+  preferredLanguage String    @default("en")
+  isNewUser         Boolean   @default(true)
+  role              UserRole  @default(user)
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  profiles          Profile[]
+  subscriptions     Subscription[]
+  payments          Payment[]
+}
+
+enum UserRole {
+  user
+  admin
+  support
+}
+
+model Profile {
+  id          String   @id @default(uuid())
+  user        User     @relation(fields: [userId], references: [id])
+  userId      String
+  name        String
+  relationship String
+  dob         DateTime
+  tob         DateTime
+  placeName   String
+  placeLat    Float
+  placeLng    Float
+  isLocked    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  horoscope   HoroscopeDaily[]
+}
+
+model Plan {
+  id                 String  @id @default(uuid())
+  name               String
+  monthlyPriceCents  Int
+  yearlyPriceCents   Int
+  maxProfiles        Int
+  features           Json
+  subscriptions      Subscription[]
+}
+
+model Subscription {
+  id              String   @id @default(uuid())
+  user            User     @relation(fields: [userId], references: [id])
+  userId          String
+  plan            Plan     @relation(fields: [planId], references: [id])
+  planId          String
+  status          SubscriptionStatus
+  period          BillingPeriod
+  currentPeriodStart DateTime
+  currentPeriodEnd   DateTime
+  razorpaySubscriptionId String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  payments        Payment[]
+}
+
+enum SubscriptionStatus {
+  active
+  canceled
+  expired
+}
+
+enum BillingPeriod {
+  monthly
+  yearly
+}
+
+model Payment {
+  id              String   @id @default(uuid())
+  user            User     @relation(fields: [userId], references: [id])
+  userId          String
+  subscription    Subscription @relation(fields: [subscriptionId], references: [id])
+  subscriptionId  String
+  razorpayPaymentId String
+  amountCents     Int
+  currency        String
+  status          PaymentStatus
+  rawWebhook      Json
+  createdAt       DateTime @default(now())
+}
+
+enum PaymentStatus {
+  success
+  failed
+  refunded
+}
+
+model FAQCategory {
+  id        String   @id @default(uuid())
+  sortOrder Int
+  key       String
+  questions FAQQuestion[]
+}
+
+model FAQQuestion {
+  id          String   @id @default(uuid())
+  category    FAQCategory @relation(fields: [categoryId], references: [id])
+  categoryId  String
+  questionKey String
+  sortOrder   Int
+  translations FAQTranslation[]
+}
+
+model FAQTranslation {
+  id          String   @id @default(uuid())
+  question    FAQQuestion @relation(fields: [questionId], references: [id])
+  questionId  String
+  langCode    String
+  questionText String
+  answerText  String
+}
+
+model HoroscopeDaily {
+  id        String   @id @default(uuid())
+  profile   Profile  @relation(fields: [profileId], references: [id])
+  profileId String
+  date      DateTime
+  rashi     String
+  contentEn String
+  contentHi String
+  contentTa String
+  contentTe String
+  createdAt DateTime @default(now())
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import userRoutes from './routes/users';
+import planRoutes from './routes/plans';
+
+const app = express();
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Dharmalayam API');
+});
+
+app.use('/auth', userRoutes);
+app.use('/plans', planRoutes);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/routes/plans.ts
+++ b/src/routes/plans.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+
+const router = Router();
+
+// Placeholder list plans
+router.get('/', async (req, res) => {
+  // TODO: Fetch from Prisma
+  res.json([
+    { id: 'free', name: 'Free', monthlyPriceCents: 0, yearlyPriceCents: 0 },
+    { id: 'pro', name: 'Pro', monthlyPriceCents: 499, yearlyPriceCents: 4999 },
+    { id: 'proplus', name: 'Pro Plus', monthlyPriceCents: 799, yearlyPriceCents: 7999 }
+  ]);
+});
+
+export default router;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+
+const router = Router();
+
+// Placeholder signup endpoint
+router.post('/signup', async (req, res) => {
+  // TODO: Validate input and create user using Prisma
+  res.json({ message: 'signup endpoint' });
+});
+
+// Placeholder login endpoint
+router.post('/login', async (req, res) => {
+  // TODO: Verify credentials
+  res.json({ message: 'login endpoint' });
+});
+
+export default router;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "build",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- initialize Node project with Express server
- define Prisma schema for core tables
- add example routes for auth and plans
- add TypeScript config and gitignore
- include README setup instructions

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68864eb30800832c9a02d1f407883267